### PR TITLE
Fix pointer lifetimes

### DIFF
--- a/Sources/Sync/RWLock/RWLock.swift
+++ b/Sources/Sync/RWLock/RWLock.swift
@@ -204,30 +204,32 @@ public final class RWLock<Wrapped>: Sync {
     private func initialize() throws {
         var attr = pthread_rwlockattr_t()
 
-        var status: Int32
+        try withUnsafeMutablePointer(to: &attr) { attrPtr in
+            var status: Int32
 
-        status = pthread_rwlockattr_init(&attr)
+            status = pthread_rwlockattr_init(attrPtr)
 
-        if let error = RWLockAttributeInitError(rawValue: status) {
-            throw error
-        }
+            if let error = RWLockAttributeInitError(rawValue: status) {
+                throw error
+            }
 
-        pthread_rwlockattr_setpshared(&attr, self.processShared.rawValue)
+            pthread_rwlockattr_setpshared(attrPtr, self.processShared.rawValue)
 
-        status = pthread_rwlock_init(&self.rwlock, &attr)
+            status = pthread_rwlock_init(&self.rwlock, attrPtr)
 
-        let rwlockInitError = RWLockInitError(rawValue: status)
+            let rwlockInitError = RWLockInitError(rawValue: status)
 
-        status = pthread_rwlockattr_destroy(&attr)
+            status = pthread_rwlockattr_destroy(attrPtr)
 
-        let rwlockAttributeDestroyError = RWLockAttributeDestroyError(rawValue: status)
+            let rwlockAttributeDestroyError = RWLockAttributeDestroyError(rawValue: status)
 
-        if let error = rwlockInitError {
-            throw error
-        }
+            if let error = rwlockInitError {
+                throw error
+            }
 
-        if let error = rwlockAttributeDestroyError {
-            throw error
+            if let error = rwlockAttributeDestroyError {
+                throw error
+            }
         }
     }
 


### PR DESCRIPTION
By storing a pointer to `self.wrapped` that was obtained via `&` we were violating lifetime guarantees.

So rather than storing such an access …

```swift
private var access: ScopedAccess<Wrapped>
// ...
self.access = .init(&self.wrapped)
// ...
try closure(self.access)
```

… we obtain the pointer ad-hoc and pass it to the closure:

```swift
try withUnsafeMutablePointer(to: &self.wrapped) { pointer in
    try closure(ScopedAccess(pointer))
}
```

And while we're at it we might as well replace a bunch of `&` with a single `withUnsafeMutablePointer(to:_:)`, too.

More info: https://developer.apple.com/forums/thread/674633

(hat-tip to @tclementdev!)